### PR TITLE
Add requirement to fetch data from API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # GovData Dashboard
 
-[GovData.de](https://www.govdata.de/) is the data portal for Germany. The federal, state and local governments can share their data. Although the "Open Data Act" makes it obligatory to share data, only about 52,000 data sets are online so far.
+[GovData.de](https://www.govdata.de/) is the data portal for Germany. The federal, state and local governments can share their data.
 
 ## Your Task
 
 Create a small web application that provides a dashboard showing how many data sets each federal ministry has made available on GovData. The dashboard should provide the possibility to filter the currently shown result set. It should be easy to tell from the dashboard which ministries have provided the most data.
 
-Data for the dashboard is going to be provided by a backend in the future, but such an API is not in place yet (imagine your colleagues are working on it). Provided already is an exemplary JSON file that resembles a response from the planned API.
+Data for the dashboard is going to be provided by a backend in the future, but such an API is not in place yet (imagine your colleagues are working on it). In the meantime please execute `npx json-server backend-response.json` to create a sample API locally. Please let your web application fetch the data from that local API.
 
 Use a non-proprietary tech stack of your choice and explain in a readme how to run your solution. Please use version control (git is preferred).
 

--- a/backend-response.json
+++ b/backend-response.json
@@ -1,137 +1,139 @@
-[
-  {
-    "department": "Statistisches Bundesamt",
-    "description": "Statistisches Bundesamt",
-    "datasets": 2372
-  },
-  {
-    "department": "Bundesministerium des Innern",
-    "description": "Bundesministerium des Innern",
-    "datasets": 722
-  },
-  {
-    "department": "Bundesamt für Justiz",
-    "description": "Bundesamt für Justiz",
-    "datasets": 662
-  },
-  {
-    "department": "mCLOUD",
-    "description": "",
-    "datasets": 648
-  },
-  {
-    "department": "Bundesministerium für Bildung und Forschung",
-    "description": "Bundesministerium für Bildung und Forschung",
-    "datasets": 457
-  },
-  {
-    "department": "Bundesministerium für Ernährung und Landwirtschaft",
-    "description": "",
-    "datasets": 141
-  },
-  {
-    "department": "Bundesministerium für Familie, Senioren, Frauen und Jugend",
-    "description": "",
-    "datasets": 65
-  },
-  {
-    "department": "Deutsches Patent- und Markenamt",
-    "description": "",
-    "datasets": 58
-  },
-  {
-    "department": "Bundesministerium der Finanzen",
-    "description": "",
-    "datasets": 53
-  },
-  {
-    "department": "Bundesministerium für Arbeit und Soziales",
-    "description": "Bundesministerium für Arbeit und Soziales",
-    "datasets": 32
-  },
-  {
-    "department": "Bundesministerium für Wirtschaft und Energie",
-    "description": "Bundesministerium für Wirtschaft und Energie",
-    "datasets": 18
-  },
-  {
-    "department": "Bundesanstalt für Arbeitsschutz und Arbeitsmedizin ",
-    "description": "",
-    "datasets": 15
-  },
-  {
-    "department": "Bundesinstitut für Bau-, Stadt- und Raumforschung (BBSR) im Bundesamt für Bauwesen und Raumordnung (BBR)",
-    "description": "",
-    "datasets": 9
-  },
-  {
-    "department": "Auswärtiges Amt",
-    "description": "",
-    "datasets": 7
-  },
-  {
-    "department": "Generalzolldirektion",
-    "description": "",
-    "datasets": 5
-  },
-  {
-    "department": "Bundesministerium der Verteidigung",
-    "description": "",
-    "datasets": 4
-  },
-  {
-    "department": "Max Rubner-Institut",
-    "description": "",
-    "datasets": 2
-  },
-  {
-    "department": "ITZ-Bund",
-    "description": "",
-    "datasets": 2
-  },
-  {
-    "department": "Bundeszentralamt für Steuern",
-    "description": "",
-    "datasets": 2
-  },
-  {
-    "department": "Bundesverwaltungsamt",
-    "description": "",
-    "datasets": 2
-  },
-  {
-    "department": "Bundesamt für Soziale Sicherung",
-    "description": "",
-    "datasets": 2
-  },
-  {
-    "department": "Bundessortenamt",
-    "description": "Bundessortenamt",
-    "datasets": 2
-  },
-  {
-    "department": "Bundesministerium für wirtschaftliche Zusammenarbeit und Entwicklung",
-    "description": "",
-    "datasets": 2
-  },
-  {
-    "department": "Bundesausgleichsamt",
-    "description": "",
-    "datasets": 2
-  },
-  {
-    "department": "Bundesanstalt für Materialforschung und -prüfung ",
-    "description": "",
-    "datasets": 2
-  },
-  {
-    "department": "Bundesamt für Verbraucherschutz und Lebensmittelsicherheit",
-    "description": "",
-    "datasets": 2
-  },
-  {
-    "department": "Bundesamt für Wirtschaft und Ausfuhrkontrolle",
-    "description": "",
-    "datasets": 1
-  }
-]
+{
+  "departments": [
+    {
+      "name": "Statistisches Bundesamt",
+      "description": "Statistisches Bundesamt",
+      "datasets": 2372
+    },
+    {
+      "name": "Bundesministerium des Innern",
+      "description": "Bundesministerium des Innern",
+      "datasets": 722
+    },
+    {
+      "name": "Bundesamt für Justiz",
+      "description": "Bundesamt für Justiz",
+      "datasets": 662
+    },
+    {
+      "name": "mCLOUD",
+      "description": "",
+      "datasets": 648
+    },
+    {
+      "name": "Bundesministerium für Bildung und Forschung",
+      "description": "Bundesministerium für Bildung und Forschung",
+      "datasets": 457
+    },
+    {
+      "name": "Bundesministerium für Ernährung und Landwirtschaft",
+      "description": "",
+      "datasets": 141
+    },
+    {
+      "name": "Bundesministerium für Familie, Senioren, Frauen und Jugend",
+      "description": "",
+      "datasets": 65
+    },
+    {
+      "name": "Deutsches Patent- und Markenamt",
+      "description": "",
+      "datasets": 58
+    },
+    {
+      "name": "Bundesministerium der Finanzen",
+      "description": "",
+      "datasets": 53
+    },
+    {
+      "name": "Bundesministerium für Arbeit und Soziales",
+      "description": "Bundesministerium für Arbeit und Soziales",
+      "datasets": 32
+    },
+    {
+      "name": "Bundesministerium für Wirtschaft und Energie",
+      "description": "Bundesministerium für Wirtschaft und Energie",
+      "datasets": 18
+    },
+    {
+      "name": "Bundesanstalt für Arbeitsschutz und Arbeitsmedizin ",
+      "description": "",
+      "datasets": 15
+    },
+    {
+      "name": "Bundesinstitut für Bau-, Stadt- und Raumforschung (BBSR) im Bundesamt für Bauwesen und Raumordnung (BBR)",
+      "description": "",
+      "datasets": 9
+    },
+    {
+      "name": "Auswärtiges Amt",
+      "description": "",
+      "datasets": 7
+    },
+    {
+      "name": "Generalzolldirektion",
+      "description": "",
+      "datasets": 5
+    },
+    {
+      "name": "Bundesministerium der Verteidigung",
+      "description": "",
+      "datasets": 4
+    },
+    {
+      "name": "Max Rubner-Institut",
+      "description": "",
+      "datasets": 2
+    },
+    {
+      "name": "ITZ-Bund",
+      "description": "",
+      "datasets": 2
+    },
+    {
+      "name": "Bundeszentralamt für Steuern",
+      "description": "",
+      "datasets": 2
+    },
+    {
+      "name": "Bundesverwaltungsamt",
+      "description": "",
+      "datasets": 2
+    },
+    {
+      "name": "Bundesamt für Soziale Sicherung",
+      "description": "",
+      "datasets": 2
+    },
+    {
+      "name": "Bundessortenamt",
+      "description": "Bundessortenamt",
+      "datasets": 2
+    },
+    {
+      "name": "Bundesministerium für wirtschaftliche Zusammenarbeit und Entwicklung",
+      "description": "",
+      "datasets": 2
+    },
+    {
+      "name": "Bundesausgleichsamt",
+      "description": "",
+      "datasets": 2
+    },
+    {
+      "name": "Bundesanstalt für Materialforschung und -prüfung ",
+      "description": "",
+      "datasets": 2
+    },
+    {
+      "name": "Bundesamt für Verbraucherschutz und Lebensmittelsicherheit",
+      "description": "",
+      "datasets": 2
+    },
+    {
+      "name": "Bundesamt für Wirtschaft und Ausfuhrkontrolle",
+      "description": "",
+      "datasets": 1
+    }
+  ]
+}


### PR DESCRIPTION
In most submissions the backend response json is imported from the file system. Understandably the simplest solution. But that way we lose an opportunity to see how applicants deal with network requests (app, tests) and potentially error handling. This PR slightly increases the difficulty of the frontend challenge.

Credits to @zechmeister for the idea to run the API server locally to keep our efforts low.